### PR TITLE
Updated scripts for run as unprivileged user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,13 @@ LABEL com.github.actions.description="Wraps the MobSF docker to enable common co
 LABEL com.github.actions.icon="package"
 LABEL com.github.actions.color="gray-dark"
 
+USER root
 RUN apt-get update -y && \
   apt-get install -y curl jq
 
+USER mobsf
 COPY LICENSE README.md /
-COPY "entrypoint.sh" "/root/Mobile-Security-Framework-MobSF/entrypoint_github.sh"
+COPY "entrypoint.sh" "/home/mobsf/Mobile-Security-Framework-MobSF/entrypoint_github.sh"
 
-ENTRYPOINT ["/root/Mobile-Security-Framework-MobSF/entrypoint_github.sh"]
+ENTRYPOINT ["/home/mobsf/Mobile-Security-Framework-MobSF/entrypoint_github.sh"]
 CMD ["--help"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,7 +25,7 @@ fi
 export MOBSF_API_KEY="$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 64)"
 export MOBSF_URL="localhost:8000"
 
-cd /root/Mobile-Security-Framework-MobSF
+cd /home/mobsf/Mobile-Security-Framework-MobSF
 python3 manage.py makemigrations 2&>> manage.out && \
 python3 manage.py makemigrations StaticAnalyzer 2&>> manage.out && \
 python3 manage.py migrate 2&>> manage.out


### PR DESCRIPTION
Fix #11 

The [commit](https://github.com/MobSF/Mobile-Security-Framework-MobSF/commit/a32154101af515af866a6339afe872367be0568a) in MobSF repo broke the current GitHub Action. This PR fixes docker build issues